### PR TITLE
Bump compatibilities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": "^7.2",
-        "laravel/framework": "~5.4.0|~5.8.0|~5.9.0|^6.0"
+        "laravel/framework": "^5.4|^6.0"
     },
     "require-dev": {
         "symfony/thanks": "^1.0"


### PR DESCRIPTION
So it can be installed on the Laravel 5.6 also.