### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
+
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/docs               export-ignore
+/imgs               export-ignore


### PR DESCRIPTION
This PR add `.gitattributes` file to reduce the size of `sweet-alert` package when we installed from packagist.

This will save disk space approximately around ~1.6MB

![image](https://user-images.githubusercontent.com/20186786/121335406-c0878c80-c944-11eb-8f5b-52578718a69f.png)



Some useful info:
https://php.watch/articles/composer-gitattributes