### PR TITLE
Add timer_progress_bar to documentation

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -153,6 +153,17 @@
 
 /*
 |--------------------------------------------------------------------------
+| Progress Bar
+|--------------------------------------------------------------------------
+| If set to true, a progress bar at the bottom of a popup will be shown.
+| It can be useful with toasts.
+|
+*/
+
+'timer_progress_bar' => env('SWEET_ALERT_TIMER_PROGRESS_BAR', false),
+
+/*
+|--------------------------------------------------------------------------
 | Middleware
 |--------------------------------------------------------------------------
 | Modal window or toast, config for the Middleware


### PR DESCRIPTION
I added the documentation about `timer_progress_bar` to your website. 
This feature #125  has been added but has not been written in the [documentation](https://github.com/realrashid/sweet-alert/blob/master/docs/environment.md), so I added the documentation