### PR TITLE
Added some features when using the alert through the session() (middlware)

### DIFF
--- a/src/ToSweetAlert.php
+++ b/src/ToSweetAlert.php
@@ -17,23 +17,51 @@ class ToSweetAlert
     public function handle($request, Closure $next)
     {
         if ($request->session()->has('success')) {
-            alert()->success($request->session()->get('success'));
+            alert()->success(
+                is_array($request->session()->get('success')) // if array is passed, put the 1st param as a title
+                    ? $request->session()->get('success')[0]
+                    : $request->session()->get('success') // else put the whole value as title
+            ,
+                is_array($request->session()->get('success')) // if array is passed, put the 1st param as a description
+                    ? $request->session()->get('success')[1]
+                    : null                                      // else put nothing as description
+            );
         }
 
         if ($request->session()->has('info')) {
-            alert()->info($request->session()->get('info'));
+            alert()->info(
+                is_array($request->session()->get('info'))
+                    ? $request->session()->get('info')[0]
+                    : $request->session()->get('info')
+            ,
+                is_array($request->session()->get('info'))
+                    ? $request->session()->get('info')[1]
+                    : null
+            );
         }
 
         if ($request->session()->has('warning')) {
-            alert()->warning($request->session()->get('warning'));
+            alert()->warning(
+                is_array($request->session()->get('warning'))
+                    ? $request->session()->get('warning')[0]
+                    : $request->session()->get('warning')
+            ,
+                is_array($request->session()->get('warning'))
+                    ? $request->session()->get('warning')[1]
+                    : null
+            );
         }
 
         if ($request->session()->has('question')) {
-            alert()->question($request->session()->get('question'));
-        }
-
-        if ($request->session()->has('info')) {
-            alert()->info($request->session()->get('info'));
+            alert()->question(
+                is_array($request->session()->get('question'))
+                    ? $request->session()->get('question')[0]
+                    : $request->session()->get('question')
+            ,
+                is_array($request->session()->get('question'))
+                    ? $request->session()->get('question')[1]
+                    : null
+            );
         }
 
         if ($request->session()->has('errors') && config('sweetalert.middleware.auto_display_error_messages')) {

--- a/src/ToSweetAlert.php
+++ b/src/ToSweetAlert.php
@@ -16,64 +16,26 @@ class ToSweetAlert
      */
     public function handle($request, Closure $next)
     {
-        if ($request->session()->has('success')) {
-            alert()->success(
-                is_array($request->session()->get('success')) // if array is passed, put the 1st param as a title
-                    ? $request->session()->get('success')[0]
-                    : $request->session()->get('success') // else put the whole value as title
-            ,
-                is_array($request->session()->get('success')) // if array is passed, put the 1st param as a description
-                    ? $request->session()->get('success')[1]
-                    : null                                      // else put nothing as description
-            );
-        }
+        $messageTypes = [
+            'info',
+           'success',
+            'warning',
+            'error',
+            'question',
+        ];
 
-        if ($request->session()->has('info')) {
-            alert()->info(
-                is_array($request->session()->get('info'))
-                    ? $request->session()->get('info')[0]
-                    : $request->session()->get('info')
-            ,
-                is_array($request->session()->get('info'))
-                    ? $request->session()->get('info')[1]
-                    : null
-            );
-        }
-
-        if ($request->session()->has('warning')) {
-            alert()->warning(
-                is_array($request->session()->get('warning'))
-                    ? $request->session()->get('warning')[0]
-                    : $request->session()->get('warning')
-            ,
-                is_array($request->session()->get('warning'))
-                    ? $request->session()->get('warning')[1]
-                    : null
-            );
-        }
-
-        if ($request->session()->has('question')) {
-            alert()->question(
-                is_array($request->session()->get('question'))
-                    ? $request->session()->get('question')[0]
-                    : $request->session()->get('question')
-            ,
-                is_array($request->session()->get('question'))
-                    ? $request->session()->get('question')[1]
-                    : null
-            );
-        }
-        
-        if ($request->session()->has('error')) {
-            alert()->question(
-                is_array($request->session()->get('error'))
-                    ? $request->session()->get('error')[0]
-                    : $request->session()->get('error')
-            ,
-                is_array($request->session()->get('error'))
-                    ? $request->session()->get('error')[1]
-                    : null
-            );
+        foreach ($messageTypes as $message) {
+            if ($request->session()->has($message)) {
+                alert()->{$message}(
+                    is_array($request->session()->get($message))
+                        ? $request->session()->get($message)[0] // if array is passed, put the 1st param as a title
+                        : $request->session()->get($message)    // else put the whole value as title
+                ,
+                    is_array($request->session()->get($message))
+                        ? $request->session()->get($message)[1] // if array is passed, put the 2st param as a description
+                        : null                                   // else put nothing as description
+                );
+            }
         }
 
         if ($request->session()->has('errors') && config('sweetalert.middleware.auto_display_error_messages')) {

--- a/src/ToSweetAlert.php
+++ b/src/ToSweetAlert.php
@@ -63,6 +63,18 @@ class ToSweetAlert
                     : null
             );
         }
+        
+        if ($request->session()->has('error')) {
+            alert()->question(
+                is_array($request->session()->get('error'))
+                    ? $request->session()->get('error')[0]
+                    : $request->session()->get('error')
+            ,
+                is_array($request->session()->get('error'))
+                    ? $request->session()->get('error')[1]
+                    : null
+            );
+        }
 
         if ($request->session()->has('errors') && config('sweetalert.middleware.auto_display_error_messages')) {
             $error = $request->session()->get('errors');


### PR DESCRIPTION
### Added passing the **description** parameter : https://github.com/realrashid/sweet-alert/pull/151/commits/021544ac218d586b35ba3e2d3a12e72de3e8670b
When using the alert through the laravel session like : `...->with('success', 'test title')` you can't pass the description like when you're using the alert() through it's native Faced or helpers ex: `alert('title', 'description', 'success')`.
  - So now I've modifed the `ToSweetAlert.php` middelware to be :
    - If an array was passed in the session's value (ex: `...->with('success', ['param01', 'param02']` the **1st** would be passed as an **Alert title** and the **2nd** param would be passed as a **Alert description**.
    - If a string was passed in the session's value (ex: `...->with('success', 'param01')` the **1st** param would be passed as a **Alert title**.
### Added the "error" message type : https://github.com/realrashid/sweet-alert/pull/151/commits/4f33a0abf42086a5b49aaad6154dbbbc102ca110
When using the alert through the middleware there is only one way to send an error alert which is when the validation fails or by: `...->with('errors', ['array of messages']` and those are going to be displayed as a list of messages in the style of an **Alert title**, Sometimes you wanna send a normal single error message with a **title** and a **description**, which is not possible through the middleware.
   - So now after the changes I've made to the `ToSweetAlert.php` file, you can easily do it like this: `...->with('error', 'test_error_message')`, or if we consider the change above, it would be like so: `...->with('error', ['test_error_title', 'test_error_description'])`.