### PR TITLE
Customizable default confirm/cancel button texts.

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -139,6 +139,22 @@
 'show_close_button' => env('SWEET_ALERT_CLOSE_BUTTON', false),
 
 /*
+|-----------------------------------------------------------------------
+| Confirm/Cancel Button Text
+|-----------------------------------------------------------------------
+| Change the default text of the modal buttons.
+| The texts translations will be handled by Laravel at runtime.
+| This is for the all Modal windows.
+| For specific modal just use the confirmButtonText() and
+| cancelButtonText() helper methods.
+*/
+
+'button_text' => [
+    'confirm' => env('SWEET_ALERT_CONFIRM_BUTTON_TEXT', 'OK'),
+    'cancel' => env('SWEET_ALERT_CANCEL_BUTTON_TEXT', 'Cancel'),
+],
+
+/*
 |--------------------------------------------------------------------------
 | Toast position
 |--------------------------------------------------------------------------

--- a/src/Toaster.php
+++ b/src/Toaster.php
@@ -52,6 +52,8 @@ class Toaster
             'padding' => config('sweetalert.padding'),
             'showConfirmButton' => config('sweetalert.show_confirm_button'),
             'showCloseButton' => config('sweetalert.show_close_button'),
+            'confirmButtonText' => __(config('sweetalert.button_text.confirm')),
+            'cancelButtonText' => __(config('sweetalert.button_text.cancel')),
             'timerProgressBar' => config('sweetalert.timer_progress_bar'),
             'customClass' => [
                 'container' => config('sweetalert.customClass.container'),

--- a/src/config/sweetalert.php
+++ b/src/config/sweetalert.php
@@ -163,6 +163,22 @@ return [
     'show_close_button' => env('SWEET_ALERT_CLOSE_BUTTON', false),
 
     /*
+    |-----------------------------------------------------------------------
+    | Confirm/Cancel Button Text
+    |-----------------------------------------------------------------------
+    | Change the default text of the modal buttons.
+    | The texts translations will be handled by Laravel at runtime.
+    | This is for the all Modal windows.
+    | For specific modal just use the confirmButtonText() and
+    | cancelButtonText() helper methods.
+    */
+
+    'button_text' => [
+        'confirm' => env('SWEET_ALERT_CONFIRM_BUTTON_TEXT', 'OK'),
+        'cancel' => env('SWEET_ALERT_CANCEL_BUTTON_TEXT', 'Cancel'),
+    ],
+
+    /*
     |--------------------------------------------------------------------------
     | Toast position
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Thanks for the great package. I have been using this for years.

However, I noticed that we were not able to set the default text for both confirm and cancel buttons, making it cumbersome to do trivial tasks such as changing and translating the button texts for all modals.

This PR adds the ability to:

* Allow modification of the default confirm and cancel button texts.
* Make the texts translatable by wrapping in Laravel's localization helper.

