### PR TITLE
Fix Alert Display with Encrypted Sessions

### DIFF
--- a/src/Storage/AlertSessionStore.php
+++ b/src/Storage/AlertSessionStore.php
@@ -42,27 +42,14 @@ class AlertSessionStore implements SessionStore
         $this->session->put($key, $data);
     }
 
-    // /**
-    //  * Flash multiple key/value pairs.
-    //  *
-    //  * @param  array  $data
-    //  * @return void
-    //  */
-    // public function flashMany(array $data)
-    // {
-    //     foreach ($data as $key => $value) {
-    //         $this->flash($key, $value);
-    //     }
-    // }
-    //
-    // /**
-    //  * Get a value from session storage.
-    //  *
-    //  * @param  string $key
-    //  * @return string
-    //  */
-    // public function get($key)
-    // {
-    //     return $this->session->get($key);
-    // }
+    /**
+     * Get a value from session storage.
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function get($key)
+    {
+        return $this->session->get($key);
+    }
 }

--- a/src/Storage/SessionStore.php
+++ b/src/Storage/SessionStore.php
@@ -19,4 +19,12 @@ interface SessionStore
      * @param $data
      */
     public function put($name, $data);
+
+    /**
+     * Get data from the session.
+     *
+     * @param $name
+     * @return mixed
+     */
+    public function get($name);
 }


### PR DESCRIPTION
## Description
Fixes an issue where alerts were not displaying on the frontend when session encryption is enabled in Laravel's configuration (`session.encrypt = true`).

## Changes
- Added `get()` method to `SessionStore` interface
- Implemented `get()` method in `AlertSessionStore` class to properly handle encrypted session data
- Ensures proper data retrieval when sessions are encrypted

## Related Issue
Fixes #177

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
- Tested with Laravel's session encryption enabled (`config/session.php` encrypt = true)
- Verified alert display works correctly with encrypted sessions

## Checklist:
- [x] My code follows the PSR-2 coding standards
- [x] I have commented my code where needed
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] The fix is backward compatible