### PR TITLE
Fix Typo in Docs Usage

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -93,7 +93,7 @@ alert()->html('<i>HTML</i> <u>example</u>'," You can use <b>bold text</b>, <a hr
 #### Toast
 
 ```php
-toast('Your Post as been submited!','success');
+toast('Your Post has been submited!','success');
 ```
 
 > Set the Default Toast Position in `config/sweetalert.php` file OR use the `position()` helper method!


### PR DESCRIPTION
This PR include the mistypo in docs/usage.md in the toast notification from "toast('Your Post as been submited!','success');" to "toast('Your Post has been submited!','success');" . 