### PR TITLE
Prevent alert display when loading page from browser cache

### DIFF
--- a/resources/views/alert.blade.php
+++ b/resources/views/alert.blade.php
@@ -1,4 +1,4 @@
-@if (Session::has('alert.config') || Session::has('alert.delete'))
+@if (config('sweetalert.alwaysLoadJS') === true || Session::has('alert.config') || Session::has('alert.delete'))
     @if (config('sweetalert.animation.enable'))
         <link rel="stylesheet" href="{{ config('sweetalert.animatecss') }}">
     @endif
@@ -7,7 +7,7 @@
         <link href="https://cdn.jsdelivr.net/npm/@sweetalert2/theme-{{ config('sweetalert.theme') }}" rel="stylesheet">
     @endif
 
-    @if (config('sweetalert.alwaysLoadJS') === false && config('sweetalert.neverLoadJS') === false)
+    @if (config('sweetalert.neverLoadJS') === false)
         <script src="{{ $cdn ?? asset('vendor/sweetalert/sweetalert.all.js') }}"></script>
     @endif
     <script>


### PR DESCRIPTION
This fixes the issue of when going back to a page (using the browser back btn ) that had previously an alert, the alert pops back cuz the alert content were saved with the page in browser cache.

> [!IMPORTANT]
>  This was Claude AI's solution, so I advice double checking before merging the PR 

 